### PR TITLE
perf: Optimize GitHub Actions build performance

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -8,6 +8,11 @@ on:
       - "v*.*.*"
   pull_request:
 
+# Cancel outdated builds when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: docker build
@@ -42,7 +47,8 @@ jobs:
         with:
           file: Dockerfile
           context: .
-          platforms: linux/amd64,linux/arm64
+          # Build only amd64 for PRs to save time, both platforms for main/tags
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           build-contexts: |
             messense/rust-musl-cross:amd64-musl=docker-image://messense/rust-musl-cross:x86_64-musl
             messense/rust-musl-cross:arm64-musl=docker-image://messense/rust-musl-cross:aarch64-musl

--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -2,32 +2,31 @@ name: Check and Test
 
 on: pull_request
 
+# Cancel outdated builds when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RUSTFLAGS: "-Dwarnings"
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    name: cargo check
+  check-and-test:
+    name: cargo check, clippy, test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check
-  clippy:
-    name: cargo clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets --all-features
-  test:
-    name: cargo test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      # Run check first (fastest)
+      - name: cargo check
+        run: cargo check
+      # Then clippy (reuses check artifacts)
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features
+      # Finally test (reuses build artifacts)
+      - name: cargo test
+        run: cargo test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM --platform=$BUILDPLATFORM messense/rust-musl-cross:${TARGETARCH}-musl AS builder
+FROM --platform=$BUILDPLATFORM messense/rust-musl-cross:${TARGETARCH}-musl AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
 
 ARG TARGETARCH
-
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
       echo "x86_64-unknown-linux-musl" > /target; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
@@ -11,18 +12,19 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       exit 1; \
     fi
 
-COPY Cargo.toml .
-COPY Cargo.lock .
-RUN mkdir -p src \
-    && echo 'fn main() {}' > src/main.rs \
-    && cargo build --release --target $(cat /target)
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-COPY src src
-RUN CARGO_BUILD_INCREMENTAL=true cargo build --release --target $(cat /target) \
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching layer
+RUN cargo chef cook --release --target $(cat /target) --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --target $(cat /target) \
     && cp target/$(cat /target)/release/gatehook target/release/gatehook
 
-
 FROM alpine
-
-COPY --from=builder /home/rust/src/target/release/gatehook /gatehook
+COPY --from=builder /app/target/release/gatehook /gatehook
 CMD [ "/gatehook" ]


### PR DESCRIPTION
- Combine ct.yml jobs into single job to share build artifacts
- Add concurrency groups to auto-cancel outdated builds
- Use cargo-chef in Dockerfile for better dependency caching
- Build only amd64 for PRs (both platforms for main/tags)

These changes significantly reduce build times by:
1. Eliminating redundant dependency builds across jobs
2. Canceling superseded workflow runs
3. Improving Docker layer caching with cargo-chef
4. Reducing PR build time by building single platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)