### PR TITLE
fix: Use PAT to trigger downstream workflows

### DIFF
--- a/.github/workflows/ci-autotag.yml
+++ b/.github/workflows/ci-autotag.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
       - name: Extract version from Cargo.toml
         id: get_version
@@ -29,3 +30,4 @@ jobs:
           tag: "v${{ steps.get_version.outputs.value }}"
           tag_exists_error: false
           message: "Release v${{ steps.get_version.outputs.value }}"
+          github_token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Configure the workflow to use GH_PAT instead of GITHUB_TOKEN. This is required because GITHUB_TOKEN cannot trigger other workflows (like cd-docker.yml), which is a GitHub security feature to prevent infinite loops.

With PAT authentication:
- Tag creation will now trigger cd-docker.yml workflow
- Docker images will be built automatically on version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)