### PR TITLE
feat: Add GPG signing to auto-tagging workflow

### DIFF
--- a/.github/workflows/ci-autotag.yml
+++ b/.github/workflows/ci-autotag.yml
@@ -1,0 +1,35 @@
+name: Auto Tag on Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  auto-tag:
+    name: Create version tag from Cargo.toml
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Extract version from Cargo.toml
+        id: get_version
+        uses: SebRollen/toml-action@v1.2.0
+        with:
+          file: 'Cargo.toml'
+          field: 'package.version'
+
+      - name: Create and push tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "v${{ steps.get_version.outputs.value }}"
+          tag_exists_error: false
+          message: "Release v${{ steps.get_version.outputs.value }}"
+          github_token: ${{ secrets.GH_PAT }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.GPG_PRIVATE_PASSPHRASE }}


### PR DESCRIPTION
Configure GPG signing for automatically created tags using the GPG_PRIVATE_KEY and GPG_PRIVATE_PASSPHRASE secrets.

This will enable "Verified" badges on tags created by the CI workflow, ensuring cryptographic verification of releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)