### PR TITLE
refactor: Remove hardcoded Ping!/Pong! logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "gatehook"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatehook"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Atsushi KAWASAKI <ak@xlix.org>"]
 description = "Bridge Discord Gateway (WebSocket) events to HTTP webhooks"
 edition = "2024"

--- a/src/bridge/event_bridge.rs
+++ b/src/bridge/event_bridge.rs
@@ -36,11 +36,9 @@ where
     /// Handle a message event
     ///
     /// Sends event to webhook and returns the response.
-    /// Also executes existing business logic (Ping! response).
     ///
     /// # Arguments
     ///
-    /// * `http` - The HTTP client from Context
     /// * `message` - The message event from Discord
     ///
     /// # Returns
@@ -48,7 +46,6 @@ where
     /// Response from webhook (may contain actions)
     pub async fn handle_message(
         &self,
-        http: &serenity::http::Http,
         message: &Message,
     ) -> anyhow::Result<Option<EventResponse>> {
         debug!(
@@ -57,16 +54,6 @@ where
             content = %message.content,
             "Processing message event"
         );
-
-        // Business logic: reply to "Ping!" messages
-        if message.content == "Ping!"
-            && let Err(err) = self
-                .discord_service
-                .reply_to_message(http, message.channel_id, message.id, "Pong!", false)
-                .await
-        {
-            error!(error = ?err, "Failed to send message reply");
-        }
 
         // Forward event to webhook endpoint and return response
         self.event_sender

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ impl EventHandler for Handler {
         }
 
         // Handle event (send to webhook + execute actions)
-        match self.bridge.handle_message(&ctx.http, &message).await {
+        match self.bridge.handle_message(&message).await {
             Ok(Some(event_response)) if !event_response.actions.is_empty() => {
                 // Execute actions if webhook responded with any
                 if let Err(err) = self


### PR DESCRIPTION
## Summary

Remove the hardcoded Ping!/Pong! business logic from `EventBridge`, as this functionality is now fully handled via the webhook `ResponseAction` system.

## Changes

- **EventBridge**: Remove Ping!/Pong! logic from `handle_message` method
- **API Simplification**: Remove unused `http` parameter from `handle_message`
- **Tests**: Consolidate test cases, removing dedicated ping/pong test
- **Version**: Bump to 0.5.2

## Motivation

With the implementation of the `ResponseAction` system, all bot behavior can now be controlled by webhook responses. The hardcoded Ping!/Pong! logic was originally a proof-of-concept and is no longer needed.

This change:
- ✅ Improves separation of concerns
- ✅ Makes EventBridge simpler and more focused
- ✅ Provides better flexibility (all logic webhook-driven)
- ✅ Removes 64 lines of code

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (all 6 integration tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)