### PR TITLE
refactor: Simplify Thread action by removing reply/mention parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "gatehook"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatehook"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Atsushi KAWASAKI <ak@xlix.org>"]
 description = "Bridge Discord Gateway (WebSocket) events to HTTP webhooks"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Add a reaction emoji to the message that triggered the event.
 
 #### `thread` - Create Thread
 
-Create a thread from the message that triggered the event (or send a reply if already in a thread).
+Create a thread from the message that triggered the event (or send a message if already in a thread).
 
 **Available in:** `message` handler in guild channels only (not DMs)
 
@@ -259,8 +259,6 @@ Create a thread from the message that triggered the event (or send a reply if al
   "type": "thread",
   "name": "Discussion Topic",
   "content": "Let's discuss this here!",
-  "reply": true,
-  "mention": false,
   "auto_archive_duration": 1440
 }
 ```
@@ -270,15 +268,14 @@ Create a thread from the message that triggered the event (or send a reply if al
   - If omitted, auto-generated from first line of message
   - If message is empty, defaults to "Thread"
 - `content` (string, required): Message content to send in the thread (max 2000 Unicode codepoints, auto-truncated if exceeded)
-- `reply` (boolean, optional, default: `false`): Whether to post the content as a reply to the original message
-- `mention` (boolean, optional, default: `false`): Whether to mention the author when replying (only used when `reply` is `true`)
+  - Use `<@user_id>` in content to mention users (e.g., `"<@123456789> Hello!"`)
 - `auto_archive_duration` (integer, optional, default: `1440`): Minutes until thread auto-archives
   - Valid values: `60` (1 hour), `1440` (1 day), `4320` (3 days), `10080` (1 week)
   - Invalid values default to `1440` with warning log
 
 **Behavior:**
 - **Normal channel**: Creates a new thread from the message
-- **Already in thread**: Skips thread creation, sends reply to existing thread
+- **Already in thread**: Skips thread creation, sends message to existing thread
 - **DM channel**: Fails with error (threads not supported in DMs)
 
 **Examples:**
@@ -290,17 +287,15 @@ Create a thread from the message that triggered the event (or send a reply if al
   "content": "Starting a discussion about this topic"
 }
 
-// Create thread with custom name and reply with mention
+// Create thread with custom name and mention user
 {
   "type": "thread",
   "name": "Bug Report #1234",
-  "content": "Thanks for reporting! Let's track this here.",
-  "reply": true,
-  "mention": true,
+  "content": "<@123456789> Thanks for reporting! Let's track this here.",
   "auto_archive_duration": 10080
 }
 
-// Create thread with minimal config (name auto-generated, no reply)
+// Create thread with minimal config
 {
   "type": "thread",
   "name": "Quick Discussion",
@@ -327,9 +322,7 @@ Execute multiple actions in sequence:
     {
       "type": "thread",
       "name": "Request Processing",
-      "content": "Tracking progress here!",
-      "reply": true,
-      "mention": false
+      "content": "Tracking progress here!"
     }
   ]
 }

--- a/src/adapters/event_response.rs
+++ b/src/adapters/event_response.rs
@@ -42,12 +42,6 @@ pub struct ThreadParams {
     pub name: Option<String>,
     /// Message content (any length accepted, truncated at execution if needed)
     pub content: String,
-    /// Whether to post as a reply (default: false)
-    #[serde(default)]
-    pub reply: bool,
-    /// Whether to mention when replying (default: false)
-    #[serde(default)]
-    pub mention: bool,
     /// Auto-archive duration in minutes (default: 1440)
     ///
     /// Valid values: 60, 1440, 4320, 10080
@@ -170,40 +164,24 @@ mod tests {
         r#"{"actions":[{"type":"thread","name":"Discussion","content":"Let's talk"}]}"#,
         Some("Discussion"),
         "Let's talk",
-        false,
-        false,
         1440
     )]
     #[case::without_name(
         r#"{"actions":[{"type":"thread","content":"Message"}]}"#,
         None,
         "Message",
-        false,
-        false,
-        1440
-    )]
-    #[case::with_reply(
-        r#"{"actions":[{"type":"thread","name":"Support","content":"Help needed","reply":true,"mention":true}]}"#,
-        Some("Support"),
-        "Help needed",
-        true,
-        true,
         1440
     )]
     #[case::custom_auto_archive(
         r#"{"actions":[{"type":"thread","content":"Test","auto_archive_duration":60}]}"#,
         None,
         "Test",
-        false,
-        false,
         60
     )]
     fn test_parse_thread_action(
         #[case] json: &str,
         #[case] expected_name: Option<&str>,
         #[case] expected_content: &str,
-        #[case] expected_reply: bool,
-        #[case] expected_mention: bool,
         #[case] expected_auto_archive: u16,
     ) {
         let response: EventResponse = serde_json::from_str(json).unwrap();
@@ -213,8 +191,6 @@ mod tests {
             ResponseAction::Thread(params) => {
                 assert_eq!(params.name.as_deref(), expected_name);
                 assert_eq!(params.content, expected_content);
-                assert_eq!(params.reply, expected_reply);
-                assert_eq!(params.mention, expected_mention);
                 assert_eq!(params.auto_archive_duration, expected_auto_archive);
             }
             _ => panic!("Expected Thread action"),

--- a/src/bridge/event_bridge.rs
+++ b/src/bridge/event_bridge.rs
@@ -244,35 +244,17 @@ where
         // Truncate content
         let content = truncate_content(&params.content);
 
-        // Post message
-        // Note: When creating a new thread, we can't reply to the parent message
-        // because it doesn't exist in the thread context. Only use reply when
-        // already in a thread.
-        if is_in_thread && params.reply {
-            self.discord_service
-                .reply_in_channel(http, target_channel_id, message.id, &content, params.mention)
-                .await
-                .context("Failed to send reply in thread")?;
+        // Post message to thread
+        self.discord_service
+            .send_message_to_channel(http, target_channel_id, &content)
+            .await
+            .context("Failed to send message to thread")?;
 
-            info!(
-                channel_id = %target_channel_id,
-                message_id = %message.id,
-                reply = true,
-                mention = params.mention,
-                "Successfully executed thread action with reply"
-            );
-        } else {
-            self.discord_service
-                .send_message_to_channel(http, target_channel_id, &content)
-                .await
-                .context("Failed to send message to thread")?;
-
-            info!(
-                channel_id = %target_channel_id,
-                reply = false,
-                "Successfully executed thread action"
-            );
-        }
+        info!(
+            channel_id = %target_channel_id,
+            is_in_thread = is_in_thread,
+            "Successfully executed thread action"
+        );
 
         Ok(())
     }

--- a/tests/adapters/mock_discord.rs
+++ b/tests/adapters/mock_discord.rs
@@ -39,7 +39,6 @@ pub struct RecordedMessage {
     pub channel_id: ChannelId,
     pub content: String,
     pub reply_to: Option<MessageId>,
-    pub mention: bool,
 }
 
 impl Default for MockDiscordService {
@@ -125,7 +124,6 @@ impl DiscordService for MockDiscordService {
             channel_id,
             content: content.to_string(),
             reply_to: None,
-            mention: false,
         });
 
         // Return a dummy Message
@@ -152,7 +150,6 @@ impl DiscordService for MockDiscordService {
             channel_id,
             content: content.to_string(),
             reply_to: Some(message_id),
-            mention,
         });
 
         // Return a dummy Message


### PR DESCRIPTION
## Summary

Refactored Thread action by removing `reply` and `mention` parameters to achieve a simpler and clearer design.

## Background & Issues

### Bug Discovery

When `reply: true` was specified during thread creation, the following error occurred:

```
Failed to execute action, continuing with next err=Failed to send reply in thread Caused by: Invalid Form Body (message_reference: Unknown message)
```

**Root Cause**: When creating a new thread, the code attempted to reply to the parent channel's message ID from within the newly created thread. However, per Discord's specification, parent channel messages don't exist within the thread context.

### Design Issues

While investigating the bug, the following design problems with the Thread action were identified:

1. **Complex conditional logic**: `reply`/`mention` parameters only function when "already in a thread" and are ignored during new thread creation
2. **Duplicate functionality**: Reply action already provides reply functionality, yet Thread action also has it
3. **Unpredictable behavior**: Webhook implementations need to understand "when reply works," making it difficult to use

## Changes

### 1. Simplified ThreadParams

**Before:**

```rust
pub struct ThreadParams {
    pub name: Option<String>,
    pub content: String,
    pub reply: bool,          // Removed
    pub mention: bool,        // Removed
    pub auto_archive_duration: u16,
}
```

**After**:

```rust
pub struct ThreadParams {
    pub name: Option<String>,
    pub content: String,
    pub auto_archive_duration: u16,
}
```

### 2. Simplified Implementation

- Simplified execute_thread method
- Always uses send_message_to_channel (no conditional branching)
- Code reduction: 8 files, 135 lines deleted

### 3. Clear Separation of Responsibilities

| Action | Responsibility |
|--------|---------------|
| Thread | Thread creation/management and message posting |
| Reply | Message replies with mention support |

### 4. Alternative for Mentions

Mentions can be used via Discord's standard notation:

```json
{
  "type": "thread",
  "name": "Support",
  "content": "<@123456789> Thank you for your inquiry"
}
```

## Breaking Changes

⚠️ This release contains breaking changes:

- reply parameter is ignored
- mention parameter is ignored

### Migration Guide:

#### Before (v0.6.0):

```json
{
  "type": "thread",
  "name": "Support",
  "content": "Help needed",
  "reply": true,
  "mention": true
}
```

#### After (v0.6.1) - Option 1: Mention in content

```json
{
  "type": "thread",
  "name": "Support",
  "content": "<@user_id> Help needed"
}
```

#### After (v0.6.1) - Option 2: Use multiple actions

```json
{
  "actions": [
    {
      "type": "reply",
      "content": "Thread created",
      "mention": true
    },
    {
      "type": "thread",
      "name": "Support",
      "content": "Help needed"
    }
  ]
}
```

## Testing

- ✅ All tests passing (70 unit tests + 14 integration tests)
- ✅ No clippy warnings
- ✅ Test cases updated and reorganized
- Documentation Updates
- ✅ README.md - Updated Thread action description and examples
- ✅ CLAUDE.md - Updated architecture documentation

## Version

0.6.0 → 0.6.1 (patch bump)

## Checklist

- [x] Code reviewed
- [x] All tests passing
- [x] Documentation updated
- [x] Breaking changes documented
- [x] Version incremented
