### PR TITLE
Fix inconsistent YAML quoting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ MESSAGE_DIRECT=""
 READY="all"
 
 # Example 6: Log message deletions (no filtering available for delete events)
-MESSAGE_DELETE_GUILD=all
-MESSAGE_DELETE_BULK_GUILD=all
+MESSAGE_DELETE_GUILD="all"
+MESSAGE_DELETE_BULK_GUILD="all"
 
 # Example 7: Monitor DM deletions
-MESSAGE_DELETE_DIRECT=all
+MESSAGE_DELETE_DIRECT="all"
 ```
 
 ### Sender Type Classification


### PR DESCRIPTION
Standardize all environment variable values in Configuration Examples section to use double quotes. This ensures consistency with bash best practices and prevents potential issues with special characters.

Changes:
- MESSAGE_DELETE_GUILD=all → MESSAGE_DELETE_GUILD="all"
- MESSAGE_DELETE_BULK_GUILD=all → MESSAGE_DELETE_BULK_GUILD="all"
- MESSAGE_DELETE_DIRECT=all → MESSAGE_DELETE_DIRECT="all"