### PR TITLE
fix: Add issues:write permission to security audit workflow

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -10,6 +10,9 @@ jobs:
   security-audit:
     name: Security audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

The security audit workflow has been failing on scheduled runs (daily at 00:00 UTC) with the following error:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest/issues/issues#create-an-issue
```

### Root Cause

Scheduled workflows (`schedule` trigger) have **read-only `GITHUB_TOKEN` permissions by default**, preventing the `rustsec/audit-check` action from creating issues when vulnerabilities or warnings are detected.

| Trigger | Default Permissions |
|---------|---------------------|
| `pull_request` | Read + Write (most) |
| `schedule` | **Read-only** ⚠️ |

## Solution

Add explicit permissions to the workflow job:

```yaml
permissions:
  contents: read   # Access repository code
  issues: write    # Create issues for vulnerabilities
```

## Impact

### Before
- ❌ Scheduled audits failed with permission error
- ⚠️ Vulnerabilities/warnings could not create notification issues

### After
- ✅ Scheduled audits can successfully create issues
- ✅ Automated vulnerability notifications work as intended
- ✅ No impact on PR-triggered runs (already had permissions)

## Audit Results

Current status (no action required):
- **Vulnerabilities**: 0 🎉
- **Warnings**: 1 (`fxhash 0.2.1` - unmaintained, indirect dependency)

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets` passes  
- [x] `cargo test` passes (146 tests)
- [ ] Verify scheduled workflow runs successfully (will verify after merge)

## References

- [GitHub Actions Permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
- [rustsec/audit-check Documentation](https://github.com/rustsec/audit-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)