### PR TITLE
feat: Add RESUMED event support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,4 +99,5 @@ MESSAGE_GUILD=user
 # ----------------------------------------------------------------------------
 # Context-Independent Events
 # ----------------------------------------------------------------------------
-# READY=all
+# READY=all                     # Bot connected to Discord
+# RESUMED=all                   # Session resumed after reconnection

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "gatehook"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatehook"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Atsushi KAWASAKI <ak@xlix.org>"]
 description = "Bridge Discord Gateway (WebSocket) events to HTTP webhooks"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Events are configured via environment variables in the format: `<EVENT_NAME>_<CO
       <td>Bot connected to Discord</td>
     </tr>
     <tr>
+      <td>Resumed</td>
+      <td colspan="2" align="center"><code>RESUMED</code></td>
+      <td>Session resumed after reconnection</td>
+    </tr>
+    <tr>
       <td>Message</td>
       <td><code>MESSAGE_DIRECT</code></td>
       <td><code>MESSAGE_GUILD</code></td>
@@ -143,18 +148,21 @@ MESSAGE_DIRECT=""
 # Example 5: Enable READY event forwarding
 READY="all"
 
-# Example 6: Log message deletions (no filtering available for delete events)
+# Example 6: Monitor session reconnections
+RESUMED="all"
+
+# Example 7: Log message deletions (no filtering available for delete events)
 MESSAGE_DELETE_GUILD="all"
 MESSAGE_DELETE_BULK_GUILD="all"
 
-# Example 7: Monitor DM deletions
+# Example 8: Monitor DM deletions
 MESSAGE_DELETE_DIRECT="all"
 
-# Example 8: Track reactions from users and bots
+# Example 9: Track reactions from users and bots
 REACTION_ADD_GUILD="user,bot"
 REACTION_ADD_DIRECT="user"
 
-# Example 9: Track reaction removal events
+# Example 10: Track reaction removal events
 REACTION_REMOVE_GUILD="user,bot"
 REACTION_REMOVE_DIRECT="user"
 ```
@@ -213,6 +221,25 @@ POST {HTTP_ENDPOINT}?handler=ready
 ```
 
 Contains bot connection info: user, guilds, session_id, shard. See [Discord Ready event](https://discord.com/developers/docs/topics/gateway-events#ready).
+
+### Resumed Event Payload
+
+Sent when bot successfully resumes a session after reconnection (if `RESUMED` is enabled):
+
+```
+POST {HTTP_ENDPOINT}?handler=resumed
+```
+
+```json
+{
+  "resumed": {
+    "_trace": ["..."]
+    // ... see Discord Resumed event documentation
+  }
+}
+```
+
+Contains trace information for debugging. This event indicates the bot reconnected and resumed its session without losing state. See [Discord Resumed event](https://discord.com/developers/docs/topics/gateway-events#resumed).
 
 ### Message Event Payload
 

--- a/src/bridge/event_bridge.rs
+++ b/src/bridge/event_bridge.rs
@@ -10,9 +10,10 @@ use crate::bridge::message_payload::MessagePayload;
 use crate::bridge::message_update_payload::MessageUpdatePayload;
 use crate::bridge::reaction_payload::ReactionPayload;
 use crate::bridge::ready_payload::ReadyPayload;
+use crate::bridge::resumed_payload::ResumedPayload;
 use anyhow::Context as _;
 use serenity::model::channel::{Message, Reaction};
-use serenity::model::event::MessageUpdateEvent;
+use serenity::model::event::{MessageUpdateEvent, ResumedEvent};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, GuildId, MessageId};
 use std::sync::Arc;
@@ -151,6 +152,33 @@ where
             .send("ready", &payload)
             .await
             .context("Failed to send ready event to HTTP endpoint")
+    }
+
+    /// Handle a resumed event
+    ///
+    /// Sends event to webhook and returns the response.
+    ///
+    /// # Arguments
+    ///
+    /// * `resumed` - The resumed event from Discord
+    ///
+    /// # Returns
+    ///
+    /// Response from webhook (may contain actions)
+    pub async fn handle_resumed(
+        &self,
+        resumed: &ResumedEvent,
+    ) -> anyhow::Result<Option<EventResponse>> {
+        debug!("Processing resumed event");
+
+        // Build payload with resumed event
+        let payload = ResumedPayload::new(resumed);
+
+        // Forward event to webhook endpoint and return response
+        self.event_sender
+            .send("resumed", &payload)
+            .await
+            .context("Failed to send resumed event to HTTP endpoint")
     }
 
     /// Handle a reaction add event

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -7,4 +7,5 @@ pub mod message_payload;
 pub mod message_update_payload;
 pub mod reaction_payload;
 pub mod ready_payload;
+pub mod resumed_payload;
 pub mod sender_filter;

--- a/src/bridge/resumed_payload.rs
+++ b/src/bridge/resumed_payload.rs
@@ -1,0 +1,27 @@
+use serde::Serialize;
+use serenity::model::event::ResumedEvent;
+
+/// Payload for resumed events sent to webhook
+///
+/// Contains the Discord Resumed event wrapped in a `resumed` key.
+/// This event is sent when a client has successfully resumed a previously
+/// disconnected session.
+///
+/// JSON structure:
+/// ```json
+/// {
+///   "resumed": { /* Discord Resumed event fields */ }
+/// }
+/// ```
+#[derive(Serialize)]
+pub struct ResumedPayload<'a> {
+    /// The Discord resumed event
+    pub resumed: &'a ResumedEvent,
+}
+
+impl<'a> ResumedPayload<'a> {
+    /// Create a new ResumedPayload
+    pub fn new(resumed: &'a ResumedEvent) -> Self {
+        Self { resumed }
+    }
+}

--- a/src/params.rs
+++ b/src/params.rs
@@ -76,6 +76,8 @@ pub struct Params {
     // Context-Independent Events
     #[serde(default)]
     pub ready: Option<String>,
+    #[serde(default)]
+    pub resumed: Option<String>,
 }
 
 /// Mask sensitive strings by showing only first and last few characters
@@ -117,6 +119,7 @@ impl std::fmt::Debug for Params {
             .field("reaction_remove_direct", &self.reaction_remove_direct)
             .field("reaction_remove_guild", &self.reaction_remove_guild)
             .field("ready", &self.ready)
+            .field("resumed", &self.resumed)
             .finish()
     }
 }
@@ -206,6 +209,7 @@ mod tests {
             reaction_remove_direct: None,
             reaction_remove_guild: None,
             ready: None,
+            resumed: None,
         };
 
         let debug_output = format!("{:?}", params);


### PR DESCRIPTION
## Summary

Add support for the Discord `RESUMED` gateway event, which is sent when a bot successfully resumes a session after reconnection.

## Changes

### Core Implementation
- ✅ Add `RESUMED` environment variable to `Params` struct
- ✅ Create `ResumedPayload` wrapper for event serialization
- ✅ Add `resume()` event handler in `main.rs`
- ✅ Add `handle_resumed()` method to `EventBridge`

### Documentation
- ✅ Update README.md:
  - Add RESUMED to Available Events table
  - Add configuration example
  - Add event payload documentation with example
- ✅ Update `.env.example` with RESUMED variable

### Version
- ✅ Bump version to `0.12.0` (minor version bump for new feature)

## Use Cases

The RESUMED event is useful for:
- **Monitoring bot health**: Track session reconnections
- **Detecting infrastructure issues**: Frequent reconnections may indicate network problems
- **Operational metrics**: Log reconnection patterns for analysis

## Testing

All existing tests pass:
```bash
cargo check   ✅
cargo clippy --all-targets   ✅
cargo test   ✅ (196 tests passed)
```

## Related

This follows the same pattern as the existing `READY` event handler:
- Minimal implementation (no action execution support)
- Optional via environment variable
- Context-independent (no Direct/Guild split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)